### PR TITLE
Add 'bundle' as a valid artifact type 

### DIFF
--- a/src/com/zwitserloot/ivyplusplus/eclipse/BuildEclipseProject.java
+++ b/src/com/zwitserloot/ivyplusplus/eclipse/BuildEclipseProject.java
@@ -184,7 +184,7 @@ public class BuildEclipseProject extends IvyPostResolveTask {
 				for (Artifact artifact : dep.getArtifacts(conf.getName())) {
 					if (handledArtifacts.contains(artifact.getId())) continue;
 					handledArtifacts.add(artifact.getId());
-					if (!"jar".equals(artifact.getType())) continue;
+					if (!"jar".equals(artifact.getType()) && !"bundle".equals(artifact.getType())) continue;
 					String destFileName = IvyPatternHelper.substitute(retrievePattern, artifact.getModuleRevisionId(), artifact, conf.getName(), null);
 					String sourceConf = conf.getSources();
 					String sourceAttachment = null;


### PR DESCRIPTION
hey hey,

currently, only artifact types of type 'jar' are added to the classpath in the ivy++ 'eclipsegen' target. This change adds 'bundle' in the list of valid types. 

cheers,

RJ
