### PR TITLE
Can't retrieve dependency cmdreader-1.5, cloud.github.com doesn't exist

### DIFF
--- a/buildScripts/ivy-repo/com.zwitserloot-cmdreader-1.5.xml
+++ b/buildScripts/ivy-repo/com.zwitserloot-cmdreader-1.5.xml
@@ -9,7 +9,11 @@
 		<conf name="sources" />
 	</configurations>
 	<publications>
+		<artifact conf="default" url="http://repo.maven.apache.org/maven2/com/zwitserloot/cmdreader/1.5/cmdreader-1.5.jar" />
+		<artifact type="zip" conf="sources" url="http://repo.maven.apache.org/maven2/com/zwitserloot/cmdreader/1.5/cmdreader-1.50-sources.jar" />
+<!--
 		<artifact conf="default" url="http://cloud.github.com/downloads/rzwitserloot/com.zwitserloot.cmdreader/com.zwitserloot.cmdreader-1.5.jar" />
 		<artifact type="zip" conf="sources" url="http://cloud.github.com/downloads/rzwitserloot/com.zwitserloot.cmdreader/com.zwitserloot.cmdreader-src-1.5.zip" />
+-->
 	</publications>
 </ivy-module>

--- a/buildScripts/ivy-repo/com.zwitserloot-cmdreader-1.5.xml
+++ b/buildScripts/ivy-repo/com.zwitserloot-cmdreader-1.5.xml
@@ -11,9 +11,5 @@
 	<publications>
 		<artifact conf="default" url="http://repo.maven.apache.org/maven2/com/zwitserloot/cmdreader/1.5/cmdreader-1.5.jar" />
 		<artifact type="zip" conf="sources" url="http://repo.maven.apache.org/maven2/com/zwitserloot/cmdreader/1.5/cmdreader-1.50-sources.jar" />
-<!--
-		<artifact conf="default" url="http://cloud.github.com/downloads/rzwitserloot/com.zwitserloot.cmdreader/com.zwitserloot.cmdreader-1.5.jar" />
-		<artifact type="zip" conf="sources" url="http://cloud.github.com/downloads/rzwitserloot/com.zwitserloot.cmdreader/com.zwitserloot.cmdreader-src-1.5.zip" />
--->
 	</publications>
 </ivy-module>


### PR DESCRIPTION
Hi,

It seems that the host cloud.github.com of url http://cloud.github.com/downloads/rzwitserloot/com.zwitserloot.cmdreader/com.zwitserloot.cmdreader-1.5.jar doesn't exist.

But this artifact and its source can also be retrieved from maven central. With this change, I'm able to fully build ivyplusplus.

Erwin
