### PR TITLE
Add the 'release' attribute to the Compile task

### DIFF
--- a/src/com/zwitserloot/ivyplusplus/Compile.java
+++ b/src/com/zwitserloot/ivyplusplus/Compile.java
@@ -110,6 +110,7 @@ public class Compile extends MatchingTask implements DynamicAttribute {
 		m.put("deprecation", "deprecation");
 		m.put("target", "target");
 		m.put("source", "source");
+		m.put("release", "release");
 		m.put("verbose", "verbose");
 		m.put("depend", "depend");
 		m.put("includeantruntime", "includeantruntime");


### PR DESCRIPTION
Hi,

Java 9 introduced the `--release` option to javac and this has been supported by Ant since the version 1.9.8. Could you consider supporting it as well in ivyplusplus please?

Thank you