### PR TITLE
Remove intellij development instructions from README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,10 +16,6 @@ For a more thorough example, just like at the build file of this very project (c
 
 Run `ant eclipse` first, then just load the main directory of the project as eclipse project.
 
-## Developing com.zwitserloot.ivyplusplus in intellij
-
-Run `ant intellij` first, then just load the main directory of the project as intellij project.
-
 ## Extra Tasks
 
 ### `<ivy:intellijgen>` - creates intellij project files from your ivy configuration.


### PR DESCRIPTION
The intellij ant task to generate the project files no longer exists
It was removed in 9e991803da2d67c2377abea662cd6ce8944c4069

Since ivyplusplus itself can no longer be used to add the task, my impression is that it would be more trouble than it's worth to reintroduce it. 